### PR TITLE
Add send_out command to IpConsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,19 @@ console setup_server -port 8888
 Accessing
 ---
 
-Once your program is up and running, you can connect to the specified TCP port with telnet or some other program, as in
+Once your program is up and running, you can connect to the specified TCP port with nc, telnet or some other program, as in
 
 ```
-telnet localhost 8888
+nc localhost 8888
 ```
 
 You will receive a greeting from the program, something that includes the program name ($::argv0), something like
 
 ```
-$ telnet localhost 6600
-Trying 127.0.0.1...
-Connected to localhost.localdomain.
-Escape character is '^]'.
-connect {feed_combiner - connect from 127.0.0.1 18849 - help for help}
+$ nc  localhost 8888
+connect {foo.tcl - connect from 127.0.0.1 44088 - help for help}
+set forever true
+ok true
 ```
 
 Using

--- a/tests/example.tcl
+++ b/tests/example.tcl
@@ -1,0 +1,51 @@
+#
+# An example server that can demonstrate # the debug break and continue
+#
+# Before running this program start nc to receive the connect
+# from the script.  Once connected try some TCL commands.
+# We can read variables by creating objects that are returned
+# by value. Remember puts will go to the output of the process with the IpConsole.
+#
+# dict create n $::example::n
+#
+# Then to continue type continue.  Here is an example session with this program.
+#
+# In one terminal,
+# $ tclsh tests/example.tcl
+# heartbeat
+# heartbeat
+# ...
+#
+# In a second terminal, but be fast you have ten seconds
+# $ nc -l localhost 8989
+# connect {tests/example.tcl - connect from 127.0.0.1 0 - help for help}
+# wall {breakpoint at example.tcl:14}
+# dict create n $::example::n
+# ok {n 10}
+# continue
+# ok {}
+
+source ip-console.tcl
+
+namespace eval ::example {
+
+set n 0
+IpConsole ipConsole
+# We are not starting the server.
+# But you could start one if needed.
+set forever false
+}
+
+proc ::example::heartbeat {} {
+    incr ::example::n
+    puts "hearbeat"
+    if {($::example::n % 10) == 0} {
+	    # every ten seconds stop
+	    ipConsole send_out {breakpoint at example.tcl:14}
+    }
+    # keep running events
+    after 1000 {::example::heartbeat}
+}
+
+after 1000 {::example::heartbeat}
+vwait ::example::forever


### PR DESCRIPTION
Add the ability to open a socket to a listener from the TCL program containing IpConsole instance.
The IpConsole is not required to be listening.
The remote listener must be ready or the TCL program will block.
Using send_out a "debugger" command to break program execution can be created.
See tests/example.tcl for the basic framework for a breakpoint.